### PR TITLE
bug fix for #1118 and158b13c (#1130)

### DIFF
--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -4129,7 +4129,8 @@ static LRESULT FrameOnCommand(WindowInfo* win, HWND hwnd, UINT msg, WPARAM wPara
 }
 
 static LRESULT OnFrameGetMinMaxInfo(MINMAXINFO* info) {
-    info->ptMinTrackSize.x = MIN_WIN_DX;
+	//limit windows min width to prevent render loop when siderbar is too big 
+    info->ptMinTrackSize.x = MIN_WIN_DX - SIDEBAR_MIN_WIDTH + gGlobalPrefs->sidebarDx;
     info->ptMinTrackSize.y = MIN_WIN_DY;
     return 0;
 }


### PR DESCRIPTION
* no longer crash when lenThatFits == 0

* try to prevent break in CJK sentence

try to prevent  break in CJK sentence, and some minor adjustments to the reparse logic.

* tweak lenThatFits  

get lenThatFits suits  (pageDx  -  currX)  instead of (pageDx - NewLineX()）
and some other corresponding corrections

* add lentmp

* Revert "Merge branch 'master' into pr/2"

This reverts commit caf069785b14513618bafd2370ecb13968d1c2a5, reversing
changes made to 21c252e34702801ce4e35ce97c686a73fea2d940.

* Revert "Revert "Merge branch 'master' into pr/2""

This reverts commit 07191b3564a0ce520ee6141a0f6326e631c3db17.

* Revert "Revert "Revert "Merge branch 'master' into pr/2"""

This reverts commit 85c2f512d1f0099ab5d81bfb7fa7104933cb9c04.

* Update HtmlFormatter.cpp

bug fix for  158b13c

* limit windows min width dynamically

limit windows min width to prevent render loop when siderbar is too big

* Revert "limit windows min width dynamically"

This reverts commit a5c4a2644329c8c7ae3f7fc202ffbaa6410ce27a.

* Update HtmlFormatter.cpp

* Revert "Revert "limit windows min width dynamically""

This reverts commit f1abbedebce1b56384b9aea2111ec0ba780f4785.